### PR TITLE
Fix memory leaks

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -217,7 +217,7 @@ class Collection implements \IteratorAggregate
 
     private static function evaluate($_seed, $_vars, $_code, $_before, $_after)
     {
-        $_old_handler = set_error_handler(function($severity, $message, $file, $line){
+        set_error_handler(function($severity, $message, $file, $line){
             throw new \ErrorException($message, 0, $severity, $file, $line);
         }, E_ALL ^ E_DEPRECATED ^ E_USER_DEPRECATED);
         try {
@@ -227,7 +227,7 @@ class Collection implements \IteratorAggregate
         } catch (\ParseError $e) {
             throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
         } finally {
-            set_error_handler($_old_handler);
+            restore_error_handler();
         }
         return $_result;
     }


### PR DESCRIPTION
The following snippet does not release assigned memory.

```php
$handler = function () {};
while (true) {
    $old_handler = set_error_handler($handler);
    set_error_handler($old_handler);
}
```

Use `restore_error_handler()` instead.

Related:

- https://3v4l.org/WCcS0
- https://github.com/mpyw/exceper/blob/836a371d320b85c031b73854d2669c051a8cfab2/src/Core.php#L11-L32